### PR TITLE
[tdrcLibrary] chore: Update Apache Commons lang to 3.6

### DIFF
--- a/tdrcLibrary/ivy.xml
+++ b/tdrcLibrary/ivy.xml
@@ -26,7 +26,7 @@
 	</info>
 	<dependencies>
 		<!-- APACHE -->
-		<dependency org="org.apache.commons" name="commons-lang3" rev="3.0"/>
+		<dependency org="org.apache.commons" name="commons-lang3" rev="3.6"/>
 		<!-- XML Bind -->
 		<!-- 
 		<dependency org="javax.xml.bind" name="jaxb-api" rev="2.3.1"/>


### PR DESCRIPTION
tdrcLibrary used apache-commons-lang3 v3.0, while CommonsLangPlus uses v3.6. There are no tests failing (plus it's a minor version bump), and it's useful to have the same version of a dependency. Currently this is the only version mismatch in the entire repository.

You can check the dependency list with the following Deno script:

```ts
import { expandGlob } from "https://deno.land/std@0.136.0/fs/mod.ts";
import { parse } from "https://deno.land/x/xml@2.0.4/mod.ts";
import { basename, resolve } from "https://deno.land/std@0.136.0/path/mod.ts";

type BareDependency = {
  "@org": string;
  "@name": string;
  "@rev": string | number;
};

type ParsedDependency = {
  _package: string;
  version: string;
  project: string;
};

let allDependencies: ParsedDependency[] = [];

for await (const file of expandGlob("**/ivy.xml")) {
  const xml = parse(await Deno.readTextFile(file.path));
  // @ts-ignore
  const bareDependencies = xml["ivy-module"].dependencies
    .dependency as (BareDependency | BareDependency[]);
  const fileDependencies = [bareDependencies].flatMap((d) => d);
  allDependencies = [
    ...allDependencies,
    ...fileDependencies.map((d) => {
      return {
        _package: `${d["@org"]}.${d["@name"]}`,
        version: "" + d["@rev"],
        project: basename(resolve(file.path, "..")),
      };
    }),
  ];
}

allDependencies.sort((d1, d2) => {
  if (d1._package.localeCompare(d2._package) !== 0) {
    return d1._package.localeCompare(d2._package);
  }
  if (d1.version.localeCompare(d2.version) !== 0) {
    return d1.version.localeCompare(d2.version);
  }
  return d1.project.localeCompare(d2.project);
});

// console.log(allDependencies);

await Deno.writeTextFile(
  "./ivy_list.txt",
  allDependencies.map(({ _package, version, project }) =>
    `${_package}@${version} - ${project}`
  ).join("\n") + "\n",
);
```
